### PR TITLE
Setup add season to game team

### DIFF
--- a/lib/game_team.rb
+++ b/lib/game_team.rb
@@ -16,6 +16,8 @@ attr_reader :game_id,
             :giveaways,
             :takeaways
 
+attr_accessor :season
+
   def initialize(data)
     @game_id = data[:game_id]
     @team_id = data[:team_id]
@@ -32,5 +34,6 @@ attr_reader :game_id,
     @faceoff_win_percentage = data[:faceoffwinpercentage]
     @giveaways = data[:giveaways]
     @takeaways = data[:takeaways]
+    @season = nil
   end
 end

--- a/lib/game_team_collection.rb
+++ b/lib/game_team_collection.rb
@@ -16,4 +16,14 @@ class GameTeamCollection
       @all_game_teams << GameTeam.new(row.to_h)
     end
   end
+
+  def add_season_id(games)
+    @all_game_teams.each do |game_team|
+      games.each do |game|
+        if game_team.game_id == game.game_id
+          game_team.season = game.season
+        end
+      end
+    end
+  end
 end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -19,6 +19,7 @@ class StatTracker
     game_collection = GameCollection.new(game_path)
     team_collection = TeamCollection.new(team_path)
     game_team_collection = GameTeamCollection.new(game_teams_path)
+    game_team_collection.add_season_id(game_collection.all_games)
     @games = game_collection.all_games
     @teams = team_collection.all_teams
     @game_teams = game_team_collection.all_game_teams

--- a/test/game_team_collection_test.rb
+++ b/test/game_team_collection_test.rb
@@ -2,6 +2,7 @@ require 'minitest/autorun'
 require 'minitest/pride'
 require './lib/game_team_collection'
 require './lib/game_team'
+require './lib/game_collection'
 
 class GameTeamCollectionTest < Minitest::Test
   @@game_team_path = './data/game_teams_fixture.csv'
@@ -16,5 +17,14 @@ class GameTeamCollectionTest < Minitest::Test
     assert_instance_of Array, @@game_team_collection.all_game_teams
     assert_equal 60, @@game_team_collection.all_game_teams.size
     assert @@game_team_collection.all_game_teams.all? { |game_team| game_team.class == GameTeam}
+  end
+
+  def test_it_can_add_season_id
+    @@game_path = './data/game_teams_fixture.csv'
+    @@game_collection = GameCollection.new(@@game_path)
+    @@game_team_collection.add_season_id(@@game_collection.all_games)
+
+    assert_equal 20122013, @@game_team_collection.all_game_teams[1].season
+    assert_equal 20172018,  @@game_team_collection.all_game_teams[59].season
   end
 end

--- a/test/game_team_collection_test.rb
+++ b/test/game_team_collection_test.rb
@@ -20,7 +20,7 @@ class GameTeamCollectionTest < Minitest::Test
   end
 
   def test_it_can_add_season_id
-    game_path = './data/game_teams_fixture.csv'
+    game_path = './data/games_fixture.csv'
     game_collection = GameCollection.new(game_path)
     @@game_team_collection.add_season_id(game_collection.all_games)
 

--- a/test/game_team_collection_test.rb
+++ b/test/game_team_collection_test.rb
@@ -20,9 +20,9 @@ class GameTeamCollectionTest < Minitest::Test
   end
 
   def test_it_can_add_season_id
-    @@game_path = './data/game_teams_fixture.csv'
-    @@game_collection = GameCollection.new(@@game_path)
-    @@game_team_collection.add_season_id(@@game_collection.all_games)
+    game_path = './data/game_teams_fixture.csv'
+    game_collection = GameCollection.new(game_path)
+    @@game_team_collection.add_season_id(game_collection.all_games)
 
     assert_equal 20122013, @@game_team_collection.all_game_teams[1].season
     assert_equal 20172018,  @@game_team_collection.all_game_teams[59].season

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -48,6 +48,11 @@ class StatTrackerTest < Minitest::Test
     assert_equal 1, @@stat_tracker.total_tied_games
   end
 
+  def test_it_can_read_season_for_game_teams
+    assert_equal 20122013, @@stat_tracker.game_teams[1].season
+    assert_equal 20172018, @@stat_tracker.game_teams[59].season
+  end
+
 # ==================       Game Stat Methods Tests     ==================
 
   def test_it_can_return_total_goals_per_season

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -51,6 +51,8 @@ class StatTrackerTest < Minitest::Test
   def test_it_can_read_season_for_game_teams
     assert_equal 20122013, @@stat_tracker.game_teams[1].season
     assert_equal 20172018, @@stat_tracker.game_teams[59].season
+  end
+  
   def test_it_can_get_total_games_per_team
     expected = { 3=>9, 6=>9, 5=>8, 17=>1, 16=>7, 14=>6, 28=>10, 54=>6, 24=>4 }
 


### PR DESCRIPTION
**What was changed**
- Added a new attribute of season to game_teams and initialized as nil 
- In game_team collection, added a method to compare game_ids across game_team and game and if they match, update game_team's season attribute with the corresponding season_id
- Called this method within StatTracker's initialization and added a test to ensure that it's accessible 

**Why it was changed:** 
- There are cases in which we want to see the season_id associated with a game_teams object, but this data only lives in games

**Notes** 
- Since we're iterating through both collections, this has the potential to slow down our run time 
