### PR TITLE
Update issue in team_collection required filepath 

### DIFF
--- a/lib/team_collection.rb
+++ b/lib/team_collection.rb
@@ -1,5 +1,5 @@
 require 'csv'
-require './lib/team'
+require_relative './team'
 
 class TeamCollection
   attr_reader :all_teams


### PR DESCRIPTION
I was unable to run spec harness as the team.rb path should utilize `require_relative` and also should not have `lib` when using relative.  Fixed these issues. 