### PR TITLE
Update test assertions for team_info to reflect updated attribute names

### DIFF
--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -348,9 +348,9 @@ class StatTrackerTest < Minitest::Test
 
   def test_it_gets_team_info
     expected = {
-                "id" => "3",
+                "team_id" => "3",
                 "franchise_id" => "10",
-                "name" => "Houston Dynamo",
+                "team_name" => "Houston Dynamo",
                 "abbreviation" => "HOU",
                 "link" => "/api/v1/teams/3"
                 }


### PR DESCRIPTION
Changed the assertion values in team_info test to reflect "team_id" and "team_name" (what's required in spec harness). 

Was causing main to throw errors. 