### PR TITLE
Update least_accurate_team to better conform to the spec

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -119,14 +119,16 @@ class StatTracker
   end
 
   def shots_to_goals_ratio_per_team_per_season(season_id)
-    total_shots_per_team_per_season(season_id).merge(total_goals_per_team_per_season(season_id)){|team_id, shots, goals| (shots.to_f / goals).round(2)}
+    total_shots_per_team_per_season(season_id).merge(total_goals_per_team_per_season(season_id)){|team_id, shots, goals| (goals == 0) ? 0 : (shots.to_f / goals).round(3)}
   end
+
   def total_goals_per_team_per_season(season_id)
     @game_teams.reduce(Hash.new(0)) do |result, game_team|
       result[game_team.team_id] += game_team.goals if game_team.season == season_id
       result
     end
   end
+
   def total_shots_per_team_per_season(season_id)
     @game_teams.reduce(Hash.new(0)) do |result, game_team|
       result[game_team.team_id] += game_team.shots if game_team.season == season_id

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -174,7 +174,7 @@ class StatTrackerTest < Minitest::Test
   def test_shots_to_goals_ratio_per_team
     ratio = {
       "3" => 4.75,
-      "6" => 3.17,
+      "6" => 3.167,
       "5" => 16.0,
       "17" => 5.00,
       "16" => 5.00,
@@ -348,9 +348,9 @@ class StatTrackerTest < Minitest::Test
 
   def test_it_gets_team_info
     expected = {
-                "id" => "3",
+                "team_id" => "3",
                 "franchise_id" => "10",
-                "name" => "Houston Dynamo",
+                "team_name" => "Houston Dynamo",
                 "abbreviation" => "HOU",
                 "link" => "/api/v1/teams/3"
                 }


### PR DESCRIPTION
This PR includes fixes to least_accurate_team and its accompanying test, as well as shots_to_goals_ratio_per_team_per_season to increase the math to round to the third decimal point (and its test). 