### PR TITLE
Bug rival calculation

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -340,7 +340,7 @@ class StatTracker
   end
 
   def rival(team_id)
-    find_team(opponents_and_num_result_for_team(team_id, "LOSS").max_by {|opponent, num_result| num_result}[0]).name
+    find_team(opponents_and_opponent_win_percent_for_team(team_id).max_by {|opponent, win_percentage| win_percentage}[0]).name
   end
 
   def fewest_goals_scored(team_id)
@@ -369,7 +369,6 @@ class StatTracker
   end
 
   def favorite_opponent(team_id)
-    find_team(opponents_and_num_result_for_team(team_id, "WIN").max_by {|opponent, num_result| num_result}[0]).name
+    find_team(opponents_and_opponent_win_percent_for_team(team_id).min_by {|opponent, win_percentage| win_percentage}[0]).name
   end
-
 end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -148,9 +148,10 @@ class StatTracker
     game.result == result
   end
 
-  def opponents_and_num_result_for_team(team_id, game_result)
+  def opponents_and_opponents_num_result_for_team(team_id, game_result)
     opponent_by_game_id_for_team(team_id).reduce(Hash.new(0)) do |result, game_id_oppo_ary|
-      result[game_id_oppo_ary[1]] += 1 if game_result?(game_result, team_id, game_id_oppo_ary[0])
+      result[game_id_oppo_ary[1]] += 0 
+      result[game_id_oppo_ary[1]] += 1 if game_result?(game_result, game_id_oppo_ary[1], game_id_oppo_ary[0])
       result
     end
   end
@@ -196,6 +197,16 @@ class StatTracker
      find_all_wins_by_coach(season_id).merge(number_of_games_by_coach(season_id)) do |head_coach, wins, games|
       (wins.to_f / games).round(2)
     end
+  end
+
+  def num_games_per_opponent_for_team(team_id)
+    opponent_by_game_id_for_team(team_id).each_with_object(Hash.new(0)) do |(game_id, team_id), result| 
+      result[team_id] += 1 if team_id == team_id 
+    end 
+  end
+
+  def opponents_and_opponent_win_percent_for_team(team_id) 
+    opponents_and_opponents_num_result_for_team(team_id, "WIN").merge(num_games_per_opponent_for_team(team_id)){|team_id, wins, games| (wins.to_f / games).round(2)}
   end
 
 # ==================       Game Stats Methods      ==================

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -236,7 +236,7 @@ class StatTrackerTest < Minitest::Test
   end
 
   def test_it_can_return_opponents_and_num_result_for_team
-    assert_equal ({"6"=>5,"5"=>0}), @@stat_tracker.opponents_and_num_result_for_team("3", "WIN")
+    assert_equal ({"6"=>5,"5"=>0}), @@stat_tracker.opponents_and_opponents_num_result_for_team("3", "WIN")
   end
 
   def test_it_can_get_game_teams_by_coach_for_season

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -236,7 +236,7 @@ class StatTrackerTest < Minitest::Test
   end
 
   def test_it_can_return_opponents_and_num_result_for_team
-    assert_equal ({"6"=>5}), @@stat_tracker.opponents_and_num_result_for_team("3", "LOSS")
+    assert_equal ({"6"=>5,"5"=>0}), @@stat_tracker.opponents_and_num_result_for_team("3", "WIN")
   end
 
   def test_it_can_get_game_teams_by_coach_for_season
@@ -257,6 +257,14 @@ class StatTrackerTest < Minitest::Test
   def test_percent_wins_by_coach
     assert_equal ({"John Tortorella"=>0.0, "Claude Julien"=>1.0, "Dan Bylsma"=>0.0, "Mike Babcock"=>0.0, "Joel Quenneville"=>1.0}),
     @@stat_tracker.percent_wins_by_coach("20122013")
+  end
+
+  def test_it_can_return_num_games_by_opponent 
+    assert_equal ({"6"=>5, "5"=>4}), @@stat_tracker.num_games_per_opponent_for_team("3")
+  end
+
+  def test_it_can_return_opponents_win_percent_for_a_team
+    assert_equal ({"6"=>1.0, "5"=>0}), @@stat_tracker.opponents_and_opponent_win_percent_for_team("3")
   end
 
 # ==================       Game Stat Methods Tests     ==================


### PR DESCRIPTION
**What was done to fix this bug:** 
- Make sure opponents_and_num_result_for_team return a key/value pair even if the opponent has not won any games against a team (ex: "5" => 0)
- Divide opponents_and_num_result_for_team by the num of games they have played against each opponent
- Take the max and min for rival and favorite_opponent


closes #89 