### PR TITLE
Revert from setup method in tests to class variable storage

### DIFF
--- a/test/game_team_test.rb
+++ b/test/game_team_test.rb
@@ -3,8 +3,7 @@ require './lib/game_team'
 
 class GameTeamTest < Minitest::Test
 
-  def setup
-    @game_team = GameTeam.new({
+  @@game_team = GameTeam.new({
                                 :game_id=>"2012030221",
                                 :team_id=>"3",
                                 :hoa=>"away",
@@ -15,25 +14,24 @@ class GameTeamTest < Minitest::Test
                                 :tackles=>44
                                 })
 
-    @game_team.season = "20122013"
-    GameTeam.class_variable_set(:@@all_game_teams, [])
-    GameTeam.create('./data/game_teams_fixture.csv')
-  end
+  @@game_team.season = "20122013"
+  GameTeam.class_variable_set(:@@all_game_teams, [])
+  GameTeam.create('./data/game_teams_fixture.csv')
 
   def test_it_exists
-    assert_instance_of GameTeam, @game_team
+    assert_instance_of GameTeam, @@game_team
   end
 
   def test_it_has_readable_attributes
-    assert_equal "2012030221", @game_team.game_id
-    assert_equal "3", @game_team.team_id
-    assert_equal "away", @game_team.hoa
-    assert_equal "LOSS", @game_team.result
-    assert_equal "John Tortorella", @game_team.head_coach
-    assert_equal 2, @game_team.goals
-    assert_equal 8, @game_team.shots
-    assert_equal 44, @game_team.tackles
-    assert_equal "20122013", @game_team.season
+    assert_equal "2012030221", @@game_team.game_id
+    assert_equal "3", @@game_team.team_id
+    assert_equal "away", @@game_team.hoa
+    assert_equal "LOSS", @@game_team.result
+    assert_equal "John Tortorella", @@game_team.head_coach
+    assert_equal 2, @@game_team.goals
+    assert_equal 8, @@game_team.shots
+    assert_equal 44, @@game_team.tackles
+    assert_equal "20122013", @@game_team.season
   end
 
   def test_it_can_return_an_array_of_info
@@ -48,8 +46,8 @@ class GameTeamTest < Minitest::Test
   end
 
   def test_it_can_generate_a_season_id
-    assert_equal "20122013", @game_team.generate_season("2012030225")
-    assert_equal "20142015", @game_team.generate_season("2014030413")
+    assert_equal "20122013", @@game_team.generate_season("2012030225")
+    assert_equal "20142015", @@game_team.generate_season("2014030413")
   end
 
   def test_it_can_get_total_home_wins

--- a/test/game_test.rb
+++ b/test/game_test.rb
@@ -1,27 +1,23 @@
 require './test/helper_test'
 require './lib/game'
-require './lib/helpable'
 
 class GameTest < Minitest::Test
-  extend Helpable
 
-  def setup
-    @game = Game.new({:game_id => "2012030221", :season => "20122013", :type => "Postseason", :date_time => "5/16/13", :away_team_id => "3", :home_team_id => "6", :away_goals => 2, :home_goals => 3, :venue => "Toyota Stadium", :venue_link => "/api/v1/venues/null"})
+    @@game = Game.new({:game_id => "2012030221", :season => "20122013", :type => "Postseason", :date_time => "5/16/13", :away_team_id => "3", :home_team_id => "6", :away_goals => 2, :home_goals => 3, :venue => "Toyota Stadium", :venue_link => "/api/v1/venues/null"})
     Game.class_variable_set(:@@all_games, [])
     Game.create('./data/games_fixture.csv')
-  end
 
   def test_it_exists
-    assert_instance_of Game, @game
+    assert_instance_of Game, @@game
   end
 
   def test_it_can_read_info
-    assert_equal "2012030221", @game.game_id
-    assert_equal "20122013", @game.season
-    assert_equal "3", @game.away_team_id
-    assert_equal "6", @game.home_team_id
-    assert_equal 2, @game.away_goals
-    assert_equal 3, @game.home_goals
+    assert_equal "2012030221", @@game.game_id
+    assert_equal "20122013", @@game.season
+    assert_equal "3", @@game.away_team_id
+    assert_equal "6", @@game.home_team_id
+    assert_equal 2, @@game.away_goals
+    assert_equal 3, @@game.home_goals
   end
 
   def test_it_can_return_an_array_of_info

--- a/test/team_test.rb
+++ b/test/team_test.rb
@@ -2,22 +2,20 @@ require './test/helper_test'
 require './lib/team'
 
 class TeamTest < MiniTest::Test
-  def setup
-    @team = Team.new({team_id: "1", franchiseid: "23", teamname: "Atlanta United", abbreviation: "ATL", stadium: "Mercedes-Benz Stadium", link: "/api/v1/teams/1"})
+    @@team = Team.new({team_id: "1", franchiseid: "23", teamname: "Atlanta United", abbreviation: "ATL", stadium: "Mercedes-Benz Stadium", link: "/api/v1/teams/1"})
     Team.class_variable_set(:@@all_teams, [])
     Team.create('./data/teams.csv')
-  end
 
   def test_it_exists
-    assert_instance_of Team, @team
+    assert_instance_of Team, @@team
   end
 
   def test_it_has_readable_attributes
-    assert_equal "1", @team.id
-    assert_equal "23", @team.franchise_id
-    assert_equal "Atlanta United", @team.name
-    assert_equal "ATL", @team.abbreviation
-    assert_equal "/api/v1/teams/1", @team.link
+    assert_equal "1", @@team.id
+    assert_equal "23", @@team.franchise_id
+    assert_equal "Atlanta United", @@team.name
+    assert_equal "ATL", @@team.abbreviation
+    assert_equal "/api/v1/teams/1", @@team.link
   end
 
   def test_it_can_return_an_array_of_info
@@ -30,7 +28,6 @@ class TeamTest < MiniTest::Test
   end
 
   def test_it_can_find_a_team
-    Team.create('./data/teams.csv')
     assert_equal "10", Team.find("id", "3").franchise_id
   end
 end


### PR DESCRIPTION
Instead of creating objects in a setup method, store them in class variables within each class test (shaves off some test time)